### PR TITLE
correction de l'executable linux

### DIFF
--- a/Sheep8
+++ b/Sheep8
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a7c00e63a5e6136c90d1b93c4839a01646a184214747d174a93cbb360adcb87
-size 116709288
+oid sha256:1c1f2d2f1ede180c3cdd2046bca2065bf14bce15710d3ca8e9535132a31fe16e
+size 116804168


### PR DESCRIPTION
Des dépendances lors de la création de l'exéctable sous pyinstaller pour linux manquaient. L'exécutable à donc été ajusté